### PR TITLE
On Mac/arm64 systems, MOE_ARCH return "armm", not "mac64".

### DIFF
--- a/loader.svl
+++ b/loader.svl
@@ -5,9 +5,15 @@ function InitializeFMOe opts
     opts = tagcat [opts, [templates: '']];
     local path = fpath (modenv[]).filename;
     ReadMenuFile fcat [path, 'menu-fmoe'];
-    app load flist fcat [path, 'fmoe', 'model'];
-    app load flist fcat [path, 'fmoe', 'view'];
-    app load flist fcat [path, 'fmoe', 'presenter'];
+    local s, fmoe_svls = cat[
+      flist[fcat [path, 'fmoe', 'model'], '*.svl'],
+      flist[fcat [path, 'fmoe', 'view'], '*.svl'],
+      flist[fcat [path, 'fmoe', 'presenter'], '*.svl']
+    ];
+    for s in fmoe_svls loop
+      load s;
+    endloop
+    
     ReadMenuFile fcat [path, 'fmoe', 'menu.svl'];
     fmoe_templates = opts.templates;
 endfunction

--- a/src/autofrag2svl/makefile
+++ b/src/autofrag2svl/makefile
@@ -5,10 +5,13 @@ NAME = autofrag2svl
 .DEFAULT_GOAL: all
 
 .PHONY: all
-all: $(DST)/$(NAME).lnx64.exe $(DST)/$(NAME).mac64.exe $(DST)/$(NAME).win64.exe
+all: $(DST)/$(NAME).lnx64.exe $(DST)/$(NAME).mac64.exe $(DST)/$(NAME).win64.exe $(DST)/$(NAME).armm.exe
 
 $(DST)/$(NAME).mac64.exe: $(SRC)
 	GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -o $@
+
+$(DST)/$(NAME).armm.exe: $(SRC)
+	GO111MODULE=on GOOS=darwin GOARCH=arm64 go build -o $@
 
 $(DST)/$(NAME).lnx64.exe: $(SRC)
 	GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o $@

--- a/src/cpf2svl/Makefile
+++ b/src/cpf2svl/Makefile
@@ -5,10 +5,13 @@ NAME = cpf2svl
 .DEFAULT_GOAL: all
 
 .PHONY: all
-all: $(DST)/$(NAME).lnx64.exe $(DST)/$(NAME).mac64.exe $(DST)/$(NAME).win64.exe
+all: $(DST)/$(NAME).lnx64.exe $(DST)/$(NAME).mac64.exe $(DST)/$(NAME).win64.exe $(DST)/$(NAME).armm.exe
 
 $(DST)/$(NAME).mac64.exe: $(SRC)
 	GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -o $@
+
+$(DST)/$(NAME).armm.exe: $(SRC)
+	GO111MODULE=on GOOS=darwin GOARCH=arm64 go build -o $@
 
 $(DST)/$(NAME).lnx64.exe: $(SRC)
 	GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o $@

--- a/src/fill_template/Makefile
+++ b/src/fill_template/Makefile
@@ -5,10 +5,13 @@ NAME = fill_template
 .DEFAULT_GOAL: all
 
 .PHONY: all
-all: $(DST)/$(NAME).lnx64.exe $(DST)/$(NAME).mac64.exe $(DST)/$(NAME).win64.exe
+all: $(DST)/$(NAME).lnx64.exe $(DST)/$(NAME).mac64.exe $(DST)/$(NAME).win64.exe $(DST)/$(NAME).armm.exe
 
 $(DST)/$(NAME).mac64.exe: $(SRC)
 	GO111MODULE=on GOOS=darwin GOARCH=amd64 go build -o $@
+
+$(DST)/$(NAME).armm.exe: $(SRC)
+	GO111MODULE=on GOOS=darwin GOARCH=arm64 go build -o $@
 
 $(DST)/$(NAME).lnx64.exe: $(SRC)
 	GO111MODULE=on GOOS=linux GOARCH=amd64 go build -o $@

--- a/templates/manual.ajf
+++ b/templates/manual.ajf
@@ -1,0 +1,75 @@
+&CNTRL
+  Method='MP2'
+  Memory=8000
+  ReadGeom='{{{BASENAME}}}.pdb'
+  WriteGeom='{{{BASENAME}}}.cpf'
+  Charge={{{TOTAL_CHARGE}}}
+/
+&FMOCNTRL
+  AutoFrag='OFF'
+  NF={{{NUM_FRAGS}}}
+/
+&SCF
+/
+&BASIS
+  BasisSet='{{{BASIS_SET}}}'
+/
+&OPTCNTRL
+/
+&MLFMO
+/
+&MFMO
+/
+&XUFF
+/
+&SCZV
+/
+&MP2
+/
+&MP2DNS
+/
+&MP2GRD
+/
+&MP3
+/
+&LMP2
+/
+&DFT
+/
+&PIEDA
+/
+&BSSE
+/
+&FRAGPAIR
+/
+&SOLVATION
+/
+&PBEQ
+/
+&POP
+/
+&GRIDCNTRL
+/
+&MCP
+/
+&CIS
+/
+&CISGRD
+/
+&CAFI
+/
+&POL
+/
+&GF2
+/
+&CCPT
+/
+{{{ABINITMP_FRAGMENT}}}
+&MDCNTRL
+/
+&VEL
+/
+&NHC
+/
+&TYPFRAG
+/


### PR DESCRIPTION
# Fix bug
On Mac/arm64 systems, MOE_ARCH returns "armm", not "mac64".
To fix it, compile options have been added for Makefiles of go.

# Minor edit
- Edit loader.svl
  On mac sometimes fails to load *.svl in original codes. 
- Add "manual.ajf" for manual fragmentation.
  Need for the manual fragmentation, but "sample.ajf" is ignored for loading template.
  "manual.ajf" is completely same to "sample.ajf"
```
function GetTemplates path
/*list files in the tenplate folder.

    :param path: templates directory path.
    :type path: token
    :return: Templates paths in the given directory.
    :rtype: list[token]
*/
    print path;
    local templates = ftail flist path;
    if length templates > 1 then
        return templates | not eqE [templates, 'sample.ajf']; // <- sample.ajf is ignored here.
    else
        return templates;
    endif
endfunction
```